### PR TITLE
submissions_for_assignment now renders local time

### DIFF
--- a/app/views/registrations/submissions_for_assignment.html.erb
+++ b/app/views/registrations/submissions_for_assignment.html.erb
@@ -17,7 +17,7 @@
 
 <% @submissions.each do |sub| %>
   <tr>
-    <td><%= sub.created_at %></td>
+    <td><span class="local-time"><%= sub.created_at %></span></td>
     <td><%= status_image(sub) %></td>
     <td><%= sub.raw_score || '∅' %>&nbsp;/&nbsp;<%= sub.assignment.points_available %></td>
     <td><%= show_score(sub.teacher_score) %>&nbsp;/&nbsp;<%= sub.assignment.points_available %></td>


### PR DESCRIPTION
Fixes #114 

There is only one other instance of sub.created_at being displayed, and it's in views/submissions/_row_form.html.erb , but that page does not appear to be a problem, so it remains unchanged.
