### PR TITLE
Prevent hidden grades from showing up

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -61,7 +61,7 @@
   <% bucket.assignments.order(:name).each do |assignment| %>
     <% sub = assignment.best_sub_for(@user) %>
     <% score = show_score(assignment.best_sub_for(@user).score, assignment); %>
-    <% if (score == "not ready") next else %>
+    <% unless score == "not ready" %>
       <tr>
         <td><%= link_to assignment.name, assignment %></td>
         <td><%= status_image(sub) %></td>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -60,16 +60,19 @@
 
   <% bucket.assignments.order(:name).each do |assignment| %>
     <% sub = assignment.best_sub_for(@user) %>
-    <tr>
-      <td><%= link_to assignment.name, assignment %></td>
-      <td><%= status_image(sub) %></td>
-      <td><%= assignment.submissions_for(@user).count %>
-	(<%= link_to "List", user_assignment_submissions_path(@user, assignment) %>)
-      </td>
-      <td><%= show_score(assignment.best_sub_for(@user).score, assignment) %></td>
-      <td><%= score_source(sub) %></td>
-      <td><%= (sub.nil? || sub.new_record?) ? '-' : link_to("Best", sub) %></td>
-    </tr>
+    <% score = show_score(assignment.best_sub_for(@user).score, assignment); %>
+    <% if (score == "not ready") next else %>
+      <tr>
+        <td><%= link_to assignment.name, assignment %></td>
+        <td><%= status_image(sub) %></td>
+        <td><%= assignment.submissions_for(@user).count %>
+          (<%= link_to "List", user_assignment_submissions_path(@user, assignment) %>)
+        </td>
+        <td><%= score %></td>
+        <td><%= score_source(sub) %></td>
+        <td><%= (sub.nil? || sub.new_record?) ? '-' : link_to("Best", sub) %></td>
+      </tr>
+    <% end %>
   <% end %>
 
   <tr>


### PR DESCRIPTION
This pull request addresses the issue raised here: #159 
A simple "unless" condition has been added to prevent "Not ready" assignments from being public.
